### PR TITLE
Introducing CMake, in the ARPA2 style, depends on ARPA2CM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,86 @@
+#
+# CMAKE SETUP (version, build style)
+#
+# SPDX-License-Identifier: BSD-2-Clause
+# License-Filename: LICENSE.MD
+cmake_minimum_required (VERSION 3.1 FATAL_ERROR)
+project ("ARPA2 Service Libraries" C)
+
+set (CMAKE_C_STANDARD 99)
+set (CMAKE_C_STANDARD_REQUIRED ON)
+
+include (FeatureSummary)
+find_package (ARPA2CM 0.5 NO_MODULE)
+set_package_properties (ARPA2CM PROPERTIES
+	DESCRIPTION "CMake modules for ARPA2 projects"
+	TYPE REQUIRED
+	URL "https://github.com/arpa2/arpa2cm/"
+	PURPOSE "Required for the CMake build system of libarpa2service"
+)
+
+if (ARPA2CM_FOUND)
+	set (CMAKE_MODULE_PATH
+		${CMAKE_MODULE_PATH}
+		${CMAKE_SOURCE_DIR}/cmake
+		${ARPA2CM_MODULE_PATH}
+	)
+else()
+        feature_summary (WHAT ALL)
+	message (FATAL_ERROR "ARPA2CM is required.")
+endif()
+
+include (MacroEnsureOutOfSourceBuild)
+include (MacroAddUninstallTarget)
+include (MacroGitVersionInfo)
+include (MacroCreateConfigFiles)
+include (CMakeDependentOption)
+
+macro_ensure_out_of_source_build("Do not build Quick-DER in the source directory.")
+
+#
+# OPTIONS / BUILD SETTINGS
+#
+option (DEBUG
+	"Produce verbose output while unpacking and packing DER"
+	ON)
+option (NO_TESTING
+	"Disable testing."
+	OFF)
+get_version_from_git (libarpa2service 0.0)
+
+if (NOT NO_TESTING)
+	enable_testing ()
+endif()
+
+#
+# BUILDING
+#
+add_subdirectory (src)
+add_subdirectory (test)
+
+add_uninstall_target ()
+
+#
+# PACKAGING
+#
+
+set (CPACK_PACKAGE_NAME "ARPA2-ServiceLibs")
+set (CPACK_PACKAGE_VERSION ${ARPA2-ServiceLibs_VERSION})
+set (CPACK_PACKAGE_VENDOR "ARPA2.net")
+set (CPACK_PACKAGE_CONTACT "Tim Kuijsten <TODO>")
+# License information for packaging. This uses the SPDX license
+# identifiers from https://spdx.org/licenses/
+set (CPACK_FREEBSD_PACKAGE_LICENSE "BSD-2-Clause")
+
+include (PackAllPossible)
+include (CPack)
+
+#
+# CMAKE CONFIGURATION FILES
+#
+# These make it simple to use find_package(Quick-DER) in other
+# projects, because Quick-DER can be found (and version information
+# obtained) automatically.
+#
+#TODO_NEED_PC_IN# create_config_files (ARPA2-ServiceLibs)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,67 @@
+# Build the ARPA2 Service Libraries twice: once shared, once static.
+include_directories (.)
+
+# Forward the CMake option to the compiler
+if (DEBUG)
+	add_definitions(-DDEBUG)
+endif()
+
+add_definitions(-Wall -Wextra -pedantic)
+
+set(arpa2acl_SRC
+	nai.c
+)
+
+# set(arpa2kv_SRC
+# )
+# 
+# set(arpa2sigid_SRC
+# )
+# 
+# set(arpa2group_SRC
+# )
+
+add_library(arpa2aclShared SHARED ${arpa2acl_SRC})
+set_target_properties(arpa2aclShared
+	PROPERTIES OUTPUT_NAME arpa2acl)
+
+add_library(arpa2aclStatic STATIC ${arpa2acl_SRC})
+set_target_properties(arpa2aclStatic
+	PROPERTIES OUTPUT_NAME arpa2acl)
+
+# add_library(arpa2kvShared SHARED ${arpa2kv_SRC})
+# set_target_properties(arpa2kvShared
+# 	PROPERTIES OUTPUT_NAME arpa2kv)
+# 
+# 
+# add_library(arpa2kvStatic STATIC ${arpa2kv_SRC})
+# set_target_properties(arpa2kvStatic
+# 	PROPERTIES OUTPUT_NAME arpa2kv)
+# 
+# 
+# add_library(arpa2signidShared SHARED ${arpa2signid_SRC})
+# set_target_properties(arpa2signidShared
+# 	PROPERTIES OUTPUT_NAME arpa2signid)
+# 
+# add_library(arpa2signidStatic STATIC ${arpa2signid_SRC})
+# set_target_properties(arpa2signidStatic
+# 	PROPERTIES OUTPUT_NAME arpa2signid)
+# 
+# 
+# add_library(arpa2groupShared SHARED ${arpa2group_SRC})
+# set_target_properties(arpa2groupShared
+# 	PROPERTIES OUTPUT_NAME arpa2group)
+# 
+# add_library(arpa2groupStatic STATIC ${arpa2group_SRC})
+# set_target_properties(arpa2groupStatic
+# 	PROPERTIES OUTPUT_NAME arpa2group)
+
+
+install (TARGETS arpa2aclShared #arpa2kvShared arpa2signidStatic arpa2groupShared
+	LIBRARY DESTINATION lib
+	PUBLIC_HEADER DESTINATION include/arpa2)
+install (TARGETS arpa2aclStatic #arpa2kvStatic arpa2signidStatic arpa2groupStatic
+	ARCHIVE DESTINATION lib)
+install (DIRECTORY ../include/arpa2
+	DESTINATION include
+	FILES_MATCHING PATTERN "*.h")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,17 @@
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+add_executable (testnai.test
+	${CMAKE_SOURCE_DIR}/src/nai.c		#external path
+	${CMAKE_CURRENT_SOURCE_DIR}/nai.c)	#overzealous local path for clarity
+target_link_libraries (testnai.test
+	arpa2aclStatic)
+
+add_executable (naiverify.test
+       ${CMAKE_SOURCE_DIR}/src/naiverify.c     # external path
+       ${CMAKE_SOURCE_DIR}/src/nai.c)          # external path
+
+add_test (testnai
+	testnai.test)
+add_test (naiverify
+	${CMAKE_CURRENT_SOURCE_DIR}/naiverify ${CMAKE_CURRENT_BINARY_DIR}/naiverify.test)
+

--- a/test/naiverify
+++ b/test/naiverify
@@ -1,10 +1,15 @@
 #!/bin/sh
 
 ######
-# Test the naiverify binary
+# Test the naiverify binary; the optional $1 is the executable naiverify
 ###
 
-naiverify="$(dirname $0)/../naiverify"
+if [ "$#" -ge 1 ]
+then
+	naiverify="$1"
+else
+	naiverify="$(dirname $0)/../naiverify"
+fi
 
 _haserr=0
 

--- a/test/naiverify
+++ b/test/naiverify
@@ -15,14 +15,14 @@ _haserr=0
 
 # Print error for an erroneously accepted string.
 # $1 - the tested string
-function perr_accept {
+perr_accept() {
 	_haserr=1
 	echo ERROR \""$1"\" accepted
 }
 
 # Print error for an erroneously unaccepted string.
 # $1 - the tested string
-function perr_notaccept {
+perr_notaccept() {
 	_haserr=1
 	echo ERROR \""$1"\" not accepted
 }


### PR DESCRIPTION
This commit adds support for:

```
mkdir /path/to/build
cd /path/to/build
cmake /path/to/libarpa2service
make
make test
make install
```

Tested on Mac OS X (FreeBSD).